### PR TITLE
Add prediction to mobile app

### DIFF
--- a/src/webapp/CartridgeOCRApp/README.md
+++ b/src/webapp/CartridgeOCRApp/README.md
@@ -1,0 +1,12 @@
+This is the code for the mobile Cartidge OCR Mobile app, which allows users to take pictures on their devices to add to the training set or to get a prediction on the image.
+
+# Local Deployment
+To get this running locally, run the following:
+- `cd src/webapp/CartridgeOCRApp`
+- `npm install -g @ionic/cli`
+- `ionic build`
+   - this might ask you to install react-scripts, respond yes if prompted
+- `npm install -g serve`
+- `serve -s build`
+
+The app will be running locally at [http://localhost:5000]()

--- a/src/webapp/CartridgeOCRApp/src/appConfig.json
+++ b/src/webapp/CartridgeOCRApp/src/appConfig.json
@@ -1,3 +1,4 @@
 {
-    "imageAPIURI": "http://localhost:7071/api/image-upload"
+    "imageAPIURI": "http://localhost:7071/api/image-upload",
+    "predictAPIURI": "http://3ca4da63-9969-4a9e-b85a-3d28ae14b212.westeurope.azurecontainer.io/score"
 }

--- a/src/webapp/CartridgeOCRApp/src/hooks/usePredictionApi.ts
+++ b/src/webapp/CartridgeOCRApp/src/hooks/usePredictionApi.ts
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { base64FromPath } from '@ionic/react-hooks/filesystem';
+import config from "../appConfig.json";
+import { Photo } from "./useDeviceCamera";
+import { isPlatform } from '@ionic/react';
+import { CameraResultType, CameraSource, CameraPhoto, Capacitor, FilesystemDirectory, Filesystem, Storage, Camera } from "@capacitor/core";
+import { useCamera } from '@ionic/react-hooks/camera';
+
+export function usePredictionApi() {
+    const { getPhoto } = useCamera();
+    const [prediction, setPrediction] = useState<Photo>({ filepath: "" });
+
+    const getPrediction = async () => {
+        const photo = await takePhoto();
+        console.log("took a pic!");
+        const base64photo = await convertToBase64(photo);
+        console.log(base64photo);
+        const base64prediction = await predict(base64photo);
+        console.log(base64prediction);
+
+        const fileName = "prediction" + new Date().getTime() + '.jpeg';
+        const prediction = convertToImage(base64prediction, fileName);
+        setPrediction(prediction);
+    }
+
+    const takePhoto = async () => {
+        const cameraPhoto = await getPhoto({
+            resultType: CameraResultType.Uri,
+            source: CameraSource.Camera,
+            quality: 100
+          });
+
+        return cameraPhoto;
+    };
+
+    const convertToBase64 = async (photo: CameraPhoto) => {
+        let base64Data: string;
+        
+        if (isPlatform('hybrid')) {
+            const file = await Filesystem.readFile({
+                path: photo.path!
+            });
+            base64Data = file.data;
+        } else {
+            base64Data = await base64FromPath(photo.webPath!);
+        }
+
+        // As the base64 string contains the filetype metadata at the start, we should split it out
+        const base64Items = base64Data.split(",", 2);
+        // // And trim the "data:" from the start to get the fileType
+        // const fileType = base64Items[0].replace('data:','');
+
+        return base64Items[1];
+    };
+
+    const predict = async (base64Image: string) => {
+        const predictAPIURI = config.predictAPIURI;
+
+        const body = { image: base64Image }
+        console.log(body);
+
+        // Call the prediction API
+        try {
+            const res = await fetch(
+                predictAPIURI, {
+                method: "POST",
+                body: JSON.stringify(body),
+                headers: new Headers({
+                    //'Authorization': 'Bearer ' + idToken,
+                    'Content-Type': 'application/json'
+                })
+            });
+            return await res.json();
+        } catch (error) {
+            // Handle errors posting to API
+            console.error("Error calling upload API: ", error);
+        }
+    };
+
+    const convertToImage = (base64Image: string, filepath: string) => {
+        return {
+            filepath,
+            webviewPath: `data:image/jpeg;base64,${base64Image}`
+        }
+    };
+
+    return {
+        prediction,
+        getPrediction
+    };
+}

--- a/src/webapp/CartridgeOCRApp/src/pages/Predict.tsx
+++ b/src/webapp/CartridgeOCRApp/src/pages/Predict.tsx
@@ -1,12 +1,36 @@
-import { IonContent, IonPage } from '@ionic/react';
+import { camera } from 'ionicons/icons';
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar,
+  IonFab, IonFabButton, IonIcon, IonGrid, IonRow,
+  IonCol, IonImg, IonActionSheet, IonCard, IonCardHeader,
+  IonCardTitle, IonCardSubtitle, IonCardContent, IonListHeader } from '@ionic/react';
+import { usePredictionApi } from '../hooks/usePredictionApi';
 import './Predict.css';
 
 const Predict: React.FC = () => {
+  const { prediction, getPrediction } = usePredictionApi();
   return (
     <IonPage>
       <IonContent fullscreen>
+        <IonCard>
+          <IonCardHeader>
+            <IonCardSubtitle>CartridgeOCR</IonCardSubtitle>
+            <IonCardTitle>Get prediction results</IonCardTitle>
+          </IonCardHeader>
 
-        <h3>To be implemented</h3>
+          <IonCardContent>
+            Upload an image to the prediction API to see the results. Click the camera button to take a photo & upload.
+          </IonCardContent>
+        </IonCard>
+
+        <IonCard>
+          <IonImg src={ prediction.webviewPath } />
+        </IonCard>
+
+        <IonFab vertical="bottom" horizontal="center" slot="fixed">
+          <IonFabButton onClick={() => getPrediction()}>
+            <IonIcon icon={camera}></IonIcon>
+          </IonFabButton>
+        </IonFab>
 
       </IonContent>
     </IonPage>


### PR DESCRIPTION
Added hooks and components to support getting a prediction from the prediction API. To use it, you'd need to click the camera button, then you can take a picture or select an image that already exists.

Here's an example of the result for a pre-existing image. There are some scaling issues for the image that need to be addressed in the future.
![image](https://user-images.githubusercontent.com/68254097/137412122-2afbd8e6-9348-47a1-8d41-3fbe36f5fcc7.png)
