### PR TITLE
feat(API): implement endpoint to redirect to Azure to download images…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,5 +60,7 @@ services:
     command: azurite-blob --blobHost 0.0.0.0 --blobPort 10000 -l /workspace -d /workspace/debug.log
     volumes:
       - "annotations_storage:/workspace"
+    ports:
+      - "10000:10000"  # so redirect urls for images work
     logging:
       driver: none

--- a/src/annotation/annotations_app/repos/azure_storage_provider.py
+++ b/src/annotation/annotations_app/repos/azure_storage_provider.py
@@ -1,9 +1,14 @@
+import datetime
 import logging
 import os
 import uuid
 
 from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
-from azure.storage.blob import BlobServiceClient
+from azure.storage.blob import (
+    BlobServiceClient,
+    BlobSasPermissions,
+    generate_blob_sas,
+)
 
 
 class AzureStorageProvider:
@@ -16,6 +21,17 @@ class AzureStorageProvider:
 
         if not connectionstring or not container_name:
             raise Exception("You must configure Azure storage first")
+
+        # used for generating SAS links to images, to dump all traffic on Azure
+        self.connection_info = {
+            key: value
+            for key, value in (
+                infoitem.split("=", maxsplit=1)
+                for infoitem
+                in connectionstring.strip().split(";")
+                if infoitem
+            )
+        }
 
         self.container_name = container_name
         self.client = BlobServiceClient.from_connection_string(connectionstring)
@@ -50,6 +66,31 @@ class AzureStorageProvider:
         logging.info("Retrieving file %s from storage", storage_key)
         blob_client = self.client.get_blob_client(container=self.container_name, blob=storage_key)
         return blob_client.download_blob().readall()
+
+    def get_file_presigned_link(self, storage_key, content_type):
+        """
+        https://docs.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob?view=azure-python#azure-storage-blob-generate-blob-sas
+        """
+        sas = generate_blob_sas(
+            account_name=self.connection_info["AccountName"],
+            account_key=self.connection_info["AccountKey"],
+            container_name=self.container_name,
+            blob_name=storage_key,
+            permission=BlobSasPermissions(read=True),
+            expiry=datetime.datetime.utcnow() + datetime.timedelta(hours=2),
+            content_disposition="inline",
+            content_type=content_type
+        )
+        if self.connection_info['BlobEndpoint'] == "http://annotations_objstore:10000/devstoreaccount1":
+            # local dev/demo scenario
+            host = "http://localhost:10000/devstoreaccount1"
+        else:
+            host = self.connection_info['BlobEndpoint']
+        # TODO: might think about allowing only Azure urls here, so our customers don't get
+        # redirected to some bad place if someone changes env variables (host, container)
+        # or manages to save bad storage key (we should generate it ourselves)
+        # but I'm probably overthinking it
+        return f"{host}/{self.container_name}/{storage_key}?{sas}"
 
     def delete_file(self, storage_key):
         """

--- a/src/annotation/annotations_app/views/api.py
+++ b/src/annotation/annotations_app/views/api.py
@@ -26,6 +26,7 @@ with app.test_request_context():
     spec.path(view=images.image_post)
     spec.path(view=images.image_detail)
     spec.path(view=images.image_retrieve)
+    spec.path(view=images.image_link)
     spec.path(view=images.image_delete)
     spec.path(view=images.image_annotations)
     spec.path(view=annotations.annotations_list)


### PR DESCRIPTION
… instead of proxying the binary data

https://github.com/Tech4Tracing/CartridgeOCR/issues/82

It seems to work fine for me but you have to update the UI to use /link url instead of /binary for images.

It requires a separate GET request to get the redirect, we might improve it further always calculating such link when returning the image info (`/api/v0/images` endpoint) - which will decrease requests count even further - may be done separately later. I don't want to commit/merge widget changes before the api changes are merged/deployed.

This require the env variable `STORAGE_AZURE_CONNECTIONSTRING` to be exactly the same format as [the local version](https://github.com/Tech4Tracing/CartridgeOCR/blob/ab08085813cb4b4f97468b12a7b80e3589f65c00/docker-compose.yml#L32) (@RamParameswaran please confirm) - I dont add try-except blocks for cases if it's not so it fails loudly instead and the service doesn't work at all.